### PR TITLE
Added logo/header for Cicer instance

### DIFF
--- a/ui/gcvit/src/App.js
+++ b/ui/gcvit/src/App.js
@@ -195,6 +195,14 @@ export default class App extends React.Component {
                         <HelpModal closeAction={()=>this.handleOpenModal()} />
                 </ReactModal>
 
+                <div className={'header-image'}>                                                                                                                                                                
+                    <a href="https://www.legumeinfo.org/"><img src="https://www.legumeinfo.org/assets/img/lis-logo-small.png" alt="LIS - Legume Information System"/></a>                                      
+                </div>                                                                                                                                                                                   
+                <div className={'header-container'}>     
+                    <div className={'header-title'}>GCViT: SNP Comparison Tool</div>                                                                                                        
+                    <div className={'header-caption'}>Cicer (chickpea)</div>                                                                                   
+                </div>  
+
                 <div
                     className={'pure-u-1-1 l-box fake-button'}
                     onClick={()=>{this.setState({hideOptions:!hideOptions})}}

--- a/ui/gcvit/src/index.css
+++ b/ui/gcvit/src/index.css
@@ -299,6 +299,31 @@ legend {
     z-index: 1000;
 }
 
+.header-image {
+    float:left;
+    margin-top:1em;
+    margin-bottom:.5em;
+}
+
+.header-container{
+    float:left;
+    margin-left:.5em;
+    margin-right:1em;
+    margin-top:.5em;
+    margin-bottom:.5em;
+    font-family:ProximaNova,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,sans-serif;
+}
+
+.header-title{
+    font-size:1.5em;
+    color:black;
+}
+
+.header-caption{
+    font-size:.9em; 
+    color:black;
+}
+
 
 /*----- Modals and Contents -----*/
 


### PR DESCRIPTION
Added the image that links to legumeinfo.org as well as a basic header for the tool. 